### PR TITLE
add -w option for opening MDN page in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ $ npm i @rafaelrinaldi/mdn -g
 ```sh
 $ mdn array.of
 $ mdn background-image --language=css
+$ mdn function.bind --web
 ```
 
 ## License

--- a/cli.js
+++ b/cli.js
@@ -8,12 +8,14 @@ const version = require('./package.json').version;
 const defaults = {
   boolean: [
     'help',
-    'version'
+    'version',
+    'web'
   ],
   alias: {
     h: 'help',
     v: 'version',
-    l: 'language'
+    l: 'language',
+    w: 'web'
   },
   default: {
     language: 'js'
@@ -33,6 +35,7 @@ Options:
   -v --version          Display current software version
   -h --help             Display software help and usage details
   -l --language         Specify a language to search for the keyword (defaults to "js")
+  -w --web              Open MDN page in web browser
 `;
 
 const run = options => {
@@ -48,9 +51,10 @@ const run = options => {
 
   const keyword = options._[0];
   const language = options.language || 'js';
+  const web = options.web || false;
 
   if (keyword !== undefined && keyword.length) {
-    mdn({keyword, language});
+    mdn({keyword, language, web});
   } else {
     process.stderr.write('You must provide a valid keyword\n');
     process.exit(1);

--- a/cli.js
+++ b/cli.js
@@ -9,13 +9,13 @@ const defaults = {
   boolean: [
     'help',
     'version',
-    'web'
+    'open'
   ],
   alias: {
     h: 'help',
     v: 'version',
     l: 'language',
-    w: 'web'
+    o: 'open'
   },
   default: {
     language: 'js'
@@ -35,7 +35,7 @@ Options:
   -v --version          Display current software version
   -h --help             Display software help and usage details
   -l --language         Specify a language to search for the keyword (defaults to "js")
-  -w --web              Open MDN page in web browser
+  -o --open             Open MDN page in web browser
 `;
 
 const run = options => {
@@ -51,10 +51,10 @@ const run = options => {
 
   const keyword = options._[0];
   const language = options.language || 'js';
-  const web = options.web || false;
+  const shouldOpen = options.open || false;
 
   if (keyword !== undefined && keyword.length) {
-    mdn({keyword, language, web});
+    mdn({keyword, language, shouldOpen});
   } else {
     process.stderr.write('You must provide a valid keyword\n');
     process.exit(1);

--- a/index.js
+++ b/index.js
@@ -82,7 +82,9 @@ const fetch = (keyword, language, shouldOpen) => {
   };
 
   if (shouldOpen) {
-    return open(url);
+    return new Promise(function(resolve) {
+      resolve(open(url));
+    });
   }
 
   return got(url, options)

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ const format = (markup, url) => {
   console.log(`${chalk.dim(url)}`);
 };
 
-const fetch = (keyword, language, web) => {
+const fetch = (keyword, language, shouldOpen) => {
   const parts = keyword.split('.');
   const url = `${SEARCH_URL[language]}/${parts[0]}/${parts[1] || ''}`;
   const options = {
@@ -81,7 +81,7 @@ const fetch = (keyword, language, web) => {
     }
   };
 
-  if (web) {
+  if (shouldOpen) {
     return open(url);
   }
 
@@ -100,4 +100,4 @@ const fetch = (keyword, language, web) => {
     });
 };
 
-module.exports = options => fetch(options.keyword, options.language, options.web);
+module.exports = options => fetch(options.keyword, options.language, options.shouldOpen);

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const cheerio = require('cheerio');
 const table = require('columnify');
 const chalk = require('chalk');
 const wrap = require('wordwrap')(90);
+const open = require('open');
 
 const BASE_URL = 'https://developer.mozilla.org/en-US/docs/Web';
 const SEARCH_URL = {
@@ -71,7 +72,7 @@ const format = (markup, url) => {
   console.log(`${chalk.dim(url)}`);
 };
 
-const fetch = (keyword, language) => {
+const fetch = (keyword, language, web) => {
   const parts = keyword.split('.');
   const url = `${SEARCH_URL[language]}/${parts[0]}/${parts[1] || ''}`;
   const options = {
@@ -79,6 +80,11 @@ const fetch = (keyword, language) => {
       'user-agent': 'https://github.com/rafaelrinaldi/mdn'
     }
   };
+
+  if (web) {
+    return open(url);
+  }
+
   return got(url, options)
     .then(response => {
       format(response.body, url);
@@ -94,4 +100,4 @@ const fetch = (keyword, language) => {
     });
 };
 
-module.exports = options => fetch(options.keyword, options.language);
+module.exports = options => fetch(options.keyword, options.language, options.web);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "columnify": "^1.5.4",
     "got": "^6.2.0",
     "minimist": "^1.2.0",
+    "open": "0.0.5",
     "wordwrap": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Great little project! I was actually just about to make something like this myself but you beat me to it and probably did it better than I would have :)

I wanted this feature to also just open the page in a browser from the command-line though. In particular, I wanted to be able to quickly look at something in the terminal, and then do `!! -w` to go straight to the page to read more, rather than copying the URL or searching for it again in my browser. Anyway, I made a quick stab at it for my own personal purposes. Not sure if it's something you want for your project but thought I'd submit the PR. Anyway, thanks for saving me some work by writing this!
