### PR TITLE
Add idiom option and fix lint errors

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -16,11 +16,11 @@ const defaults = {
     v: 'version',
     l: 'language',
     o: 'open',
-    i: 'idiom'
+    lc: 'locale'
   },
   default: {
     language: 'js',
-    idiom: 'en-US'
+    locale: 'en-US'
   }
 };
 const options = minimist(process.argv.slice(2), defaults);
@@ -32,14 +32,14 @@ Usage: mdn <KEYWORD>
 Example:
   $ mdn object.freeze
   $ mdn background-image --language=css
-  $ mdn background --language=css --idiom=pt-BR
+  $ mdn background --language=css --locale=pt-BR
 
 Options:
-  -v  --version         Display current software version
-  -h  --help            Display software help and usage details
-  -l  --language        Specify a language to search for the keyword (defaults to "js")
-  -o  --open            Open MDN page in web browser
-  -i  --idiom           Specify a idiom (defaults to "en-US")
+  -v   --version         Display current software version
+  -h   --help            Display software help and usage details
+  -l   --language        Specify a language to search for the keyword (defaults to "js")
+  -o   --open            Open MDN page in web browser
+  -lc  --locale          Specify a locale (defaults to "en-US")
 `;
 
 const run = options => {
@@ -56,10 +56,10 @@ const run = options => {
   const keyword = options._[0];
   const language = options.language || 'js';
   const shouldOpen = options.open || false;
-  const idiom = options.idiom || 'en-US';
+  const locale = options.locale || 'en-US';
 
   if (keyword !== undefined && keyword.length) {
-    mdn({keyword, language, shouldOpen, idiom});
+    mdn({keyword, language, shouldOpen, locale});
   } else {
     process.stderr.write('You must provide a valid keyword\n');
     process.exit(1);

--- a/cli.js
+++ b/cli.js
@@ -59,7 +59,12 @@ const run = options => {
   const locale = options.locale || 'en-US';
 
   if (keyword !== undefined && keyword.length) {
-    mdn({keyword, language, shouldOpen, locale});
+    mdn({
+      keyword, 
+      language, 
+      shouldOpen, 
+      locale
+    });
   } else {
     process.stderr.write('You must provide a valid keyword\n');
     process.exit(1);

--- a/cli.js
+++ b/cli.js
@@ -15,10 +15,12 @@ const defaults = {
     h: 'help',
     v: 'version',
     l: 'language',
-    o: 'open'
+    o: 'open',
+    i: 'idiom'
   },
   default: {
-    language: 'js'
+    language: 'js',
+    idiom: 'en-US'
   }
 };
 const options = minimist(process.argv.slice(2), defaults);
@@ -30,12 +32,14 @@ Usage: mdn <KEYWORD>
 Example:
   $ mdn object.freeze
   $ mdn background-image --language=css
+  $ mdn background --language=css --idiom=pt-BR
 
 Options:
-  -v --version          Display current software version
-  -h --help             Display software help and usage details
-  -l --language         Specify a language to search for the keyword (defaults to "js")
-  -o --open             Open MDN page in web browser
+  -v  --version         Display current software version
+  -h  --help            Display software help and usage details
+  -l  --language        Specify a language to search for the keyword (defaults to "js")
+  -o  --open            Open MDN page in web browser
+  -i  --idiom           Specify a idiom (defaults to "en-US")
 `;
 
 const run = options => {
@@ -52,9 +56,10 @@ const run = options => {
   const keyword = options._[0];
   const language = options.language || 'js';
   const shouldOpen = options.open || false;
+  const idiom = options.idiom || 'en-US';
 
   if (keyword !== undefined && keyword.length) {
-    mdn({keyword, language, shouldOpen});
+    mdn({keyword, language, shouldOpen, idiom});
   } else {
     process.stderr.write('You must provide a valid keyword\n');
     process.exit(1);

--- a/index.js
+++ b/index.js
@@ -12,9 +12,7 @@ const SEARCH_URL = {
   css: 'CSS'
 };
 
-const getBaseUrl = idiom => {
-  return `https://developer.mozilla.org/${idiom}/docs/Web`;
-};
+const getBaseUrl = locale => `https://developer.mozilla.org/${locale}/docs/Web`;
 
 const format = (markup, url) => {
   const $ = cheerio.load(markup);
@@ -75,8 +73,8 @@ const format = (markup, url) => {
   console.log(`${chalk.dim(url)}`);
 };
 
-const fetch = (keyword, language, shouldOpen, idiom) => {
-  const baseUrl = getBaseUrl(idiom);
+const fetch = (keyword, language, shouldOpen, locale) => {
+  const baseUrl = getBaseUrl(locale);
   const parts = keyword.split('.');
   const url = `${baseUrl}/${SEARCH_URL[language]}/${parts[0]}/${parts[1] || ''}`;
   const options = {
@@ -112,5 +110,5 @@ module.exports = options => fetch(
   options.keyword,
   options.language,
   options.shouldOpen,
-  options.idiom
+  options.locale
 );

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ const fetch = (keyword, language, shouldOpen) => {
   };
 
   if (shouldOpen) {
-    return new Promise(function(resolve) {
+    return new Promise(resolve => {
       resolve(open(url));
     });
   }

--- a/index.js
+++ b/index.js
@@ -7,10 +7,13 @@ const chalk = require('chalk');
 const wrap = require('wordwrap')(90);
 const open = require('open');
 
-const BASE_URL = 'https://developer.mozilla.org/en-US/docs/Web';
 const SEARCH_URL = {
-  js: `${BASE_URL}/JavaScript/Reference/Global_Objects`,
-  css: `${BASE_URL}/CSS`
+  js: 'JavaScript/Reference/Global_Objects',
+  css: 'CSS'
+};
+
+const getBaseUrl = idiom => {
+  return `https://developer.mozilla.org/${idiom}/docs/Web`;
 };
 
 const format = (markup, url) => {
@@ -72,14 +75,17 @@ const format = (markup, url) => {
   console.log(`${chalk.dim(url)}`);
 };
 
-const fetch = (keyword, language, shouldOpen) => {
+const fetch = (keyword, language, shouldOpen, idiom) => {
+  const baseUrl = getBaseUrl(idiom);
   const parts = keyword.split('.');
-  const url = `${SEARCH_URL[language]}/${parts[0]}/${parts[1] || ''}`;
+  const url = `${baseUrl}/${SEARCH_URL[language]}/${parts[0]}/${parts[1] || ''}`;
   const options = {
     headers: {
       'user-agent': 'https://github.com/rafaelrinaldi/mdn'
     }
   };
+
+  console.log(url);
 
   if (shouldOpen) {
     return new Promise(resolve => {
@@ -102,4 +108,9 @@ const fetch = (keyword, language, shouldOpen) => {
     });
 };
 
-module.exports = options => fetch(options.keyword, options.language, options.shouldOpen);
+module.exports = options => fetch(
+  options.keyword,
+  options.language,
+  options.shouldOpen,
+  options.idiom
+);


### PR DESCRIPTION
## `--idiom`

I added an option to the user to specify a language for your search.  Obviously, the default remains `en-US`.

See below:

[![asciicast](https://asciinema.org/a/41196.png)](https://asciinema.org/a/41196)
# 
## Lint erros

:nail_care:  On run `npm test`, the lint tool showed me the following errors:

![screenshot from 2016-04-03 19-09-38](https://cloud.githubusercontent.com/assets/2369851/14235280/018c3554-f9d0-11e5-8c92-da355987135d.png)

This PR also fixes it.
