### PR TITLE
removed unnecessary fallback options

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,7 +9,8 @@ const defaults = {
   boolean: [
     'help',
     'version',
-    'open'
+    'open',
+    'css'
   ],
   alias: {
     h: 'help',
@@ -21,7 +22,8 @@ const defaults = {
   default: {
     language: 'js',
     locale: 'en-US',
-    open: false
+    open: false,
+    css: false
   }
 };
 
@@ -40,6 +42,7 @@ Options:
   -v   --version         Display current software version
   -h   --help            Display software help and usage details
   -l   --language        Specify a language to search for the keyword (defaults to "js")
+       --css             Equivalent to "-l css"
   -o   --open            Open MDN page in web browser
   -lc  --locale          Specify a locale (defaults to "en-US")
 `;
@@ -56,7 +59,7 @@ const run = options => {
   }
 
   const keyword = options._[0];
-  const language = options.language;
+  const language = (options.css) ? 'css' : options.language;
   const shouldOpen = options.open;
   const locale = options.locale;
 

--- a/cli.js
+++ b/cli.js
@@ -20,9 +20,11 @@ const defaults = {
   },
   default: {
     language: 'js',
-    locale: 'en-US'
+    locale: 'en-US',
+    open: false
   }
 };
+
 const options = minimist(process.argv.slice(2), defaults);
 const help = `
 Usage: mdn <KEYWORD>
@@ -54,9 +56,9 @@ const run = options => {
   }
 
   const keyword = options._[0];
-  const language = options.language || 'js';
-  const shouldOpen = options.open || false;
-  const locale = options.locale || 'en-US';
+  const language = options.language;
+  const shouldOpen = options.open;
+  const locale = options.locale;
 
   if (keyword !== undefined && keyword.length) {
     mdn({


### PR DESCRIPTION
Very simple change. Just noticed yesterday that the default arguments are already handled by minimist and the fallback arguments are thus unnecessary
