### PR TITLE
Add css language option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,12 +9,14 @@ const defaults = {
   boolean: [
     'help',
     'version',
-    'open'
+    'open',
+    'css'
   ],
   alias: {
     h: 'help',
     v: 'version',
     l: 'language',
+    c: 'css',
     o: 'open',
     lc: 'locale'
   },
@@ -38,6 +40,7 @@ Options:
   -v   --version         Display current software version
   -h   --help            Display software help and usage details
   -l   --language        Specify a language to search for the keyword (defaults to "js")
+  -c   --css             Specify css as the language
   -o   --open            Open MDN page in web browser
   -lc  --locale          Specify a locale (defaults to "en-US")
 `;
@@ -51,6 +54,10 @@ const run = options => {
   if (options.version) {
     process.stderr.write(`mdn v${version}\n`);
     return;
+  }
+
+  if (options.css) {
+    options.language = 'css'
   }
 
   const keyword = options._[0];


### PR DESCRIPTION
I'm lazy, so I'd like to propose adding a css
option so I can

    mdn -co background-position

This might be somewhat of a unique usecase for
my preferences, so please don't feel obligated
to merge. I can always alias it.

Thanks for this project :beers:

Also, I've modified the help menu to document
this change:

    Usage: mdn <KEYWORD>

    Man pages for web APIs using MDN

    Example:
      $ mdn object.freeze
      $ mdn background-image --language=css
      $ mdn background --language=css --locale=pt-BR

    Options:
      -v   --version         Display current software version
      -h   --help            Display software help and usage details
      -l   --language        Specify a language to search for the keyword (defaults to "js")
      -c   --css             Specify css as the language
      -o   --open            Open MDN page in web browser
      -lc  --locale          Specify a locale (defaults to "en-US")