### PR TITLE
Output refactor & add return value

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,9 @@ const format = (markup, url) => {
       const isNested = $element.parent().parent().is('dd');
 
       const term = $element
+        .find('code')
+        .contents()
+        .not('span')
         .text()
         .replace(/^/, isNested ? '  ' : '');
 

--- a/index.js
+++ b/index.js
@@ -50,11 +50,18 @@ const format = (markup, url) => {
     .has('code')
     .each((index, element) => {
       const $element = $(element);
-      const term = $element.text();
+      const isNested = $element.parent().parent().is('dd');
+
+      const term = $element
+        .text()
+        .replace(/^/, isNested ? '  ' : '');
+
       const definition = $element
         .next('dd')
+        .contents()
+        .not('dl')
         .text()
-        .replace(new RegExp(term, 'gim'), chalk.bold(term));
+        .replace(new RegExp(term.trim(), 'gim'), chalk.bold(term.trim()));
 
       api.push({
         term: chalk.bold(term),

--- a/index.js
+++ b/index.js
@@ -83,6 +83,13 @@ const format = (markup, url) => {
     }
   }));
 
+  const returnValue = $('#Return_value + p').text();
+
+  if (returnValue.length > 0) {
+    const recased = returnValue[0].toLowerCase() + returnValue.substr(1);
+    console.log(`\n${wrap(chalk.bold('Returns ') + recased)}\n`);
+  }
+
   console.log(`${chalk.dim(url)}`);
 };
 


### PR DESCRIPTION
Removes duplication from the callback argument as in the other PR I just closed earlier, but in a less convoluted way.

Adds return value (if it exists) to the output.

Removes `span` tags from the definition output as well (it would otherwise show things like `thisArg Optional   Optional.` whenever tags were present in the source html)

Sample output for `mdn array.filter`:

```

Array.prototype.filter()

The filter() method creates a new array with all elements that pass the test
implemented by the provided function.

	0 | var newArray = arr.filter(callback[, thisArg])


callback        Function is a predicate, to test each element of the array.   
                Return true to keep the element, false otherwise, taking three
                arguments:                                                    
                                                                              
  element       The current element being processed in the array.             
                                                                              
  index         The index of the current element being processed in the array.
                                                                              
  array         The array filter was called upon.                             
                                                                              
thisArg         Optional. Value to use as this when executing callback.       
                                                                              

Returns a new array with the elements that pass the test.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/array/filter
```